### PR TITLE
Refactor DDSM115DriverClient to use a constant baud rate

### DIFF
--- a/include/ddsm115_ros2_driver/ddsm115_ros2_driver_client.hpp
+++ b/include/ddsm115_ros2_driver/ddsm115_ros2_driver_client.hpp
@@ -22,7 +22,7 @@ public:
   // Destructor
   ~DDSM115DriverClient();
 
-  bool init_port(const std::string &port_name, int baud_rate);
+  bool init_port(const std::string &port_name);
   bool reinitialize_port();
   void close_port();
 

--- a/src/ddsm115_ros2_driver_client.cpp
+++ b/src/ddsm115_ros2_driver_client.cpp
@@ -7,6 +7,8 @@
 #include <condition_variable>
 #include <future>
 
+constexpr uint32_t BAUD_RATE = 115200;
+
 namespace ddsm115_ros2_driver {
 
 uint8_t DDSM115DriverClient::calc_crc8_maxim(const std::vector<uint8_t>& data) {
@@ -55,10 +57,10 @@ void DDSM115DriverClient::close_port() {
   }
 }
 
-bool DDSM115DriverClient::init_port(const std::string& port_name, int baud_rate) {
+bool DDSM115DriverClient::init_port(const std::string& port_name) {
   try {
     this->port_name_ = port_name;
-    this->baud_rate_ = baud_rate;
+    this->baud_rate_ = BAUD_RATE;
     serial_port_.open(this->port_name_);
     serial_port_.set_option(boost::asio::serial_port_base::baud_rate(this->baud_rate_));
     serial_port_.set_option(boost::asio::serial_port_base::character_size(8));
@@ -98,7 +100,7 @@ bool DDSM115DriverClient::reinitialize_port() {
   // 少し待つ（デバイス側のリセット待ち）
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-  return init_port(port_name_, baud_rate_);
+  return init_port(port_name_);
 }
 
 void DDSM115DriverClient::send_mode_command(uint8_t motor_id, ControlLoopModes mode) {

--- a/src/ddsm115_ros2_driver_node.cpp
+++ b/src/ddsm115_ros2_driver_node.cpp
@@ -26,7 +26,6 @@ public:
 
     // Get parameters
     serial_port_ = this->get_parameter("serial_port").as_string();
-    baud_rate_ = this->get_parameter("baud_rate").as_int();
     double publish_rate = this->get_parameter("publish_rate").as_double();
     std::vector<int64_t> motor_ids = this->get_parameter("motor_ids").as_integer_array();
 
@@ -36,7 +35,7 @@ public:
       this->get_logger(),
       std::bind(&DDSM115DriverNode::motor_feedback_callback, this, std::placeholders::_1));
 
-    if (!driver_client_->init_port(serial_port_, baud_rate_)) {
+    if (!driver_client_->init_port(serial_port_)) {
       RCLCPP_ERROR(this->get_logger(), "Failed to initialize serial port");
       rclcpp::shutdown();
       return;
@@ -74,7 +73,6 @@ public:
     
     RCLCPP_INFO(this->get_logger(), "DDSM115 Driver Node initialized");
     RCLCPP_INFO(this->get_logger(), "Serial port: %s", serial_port_.c_str());
-    RCLCPP_INFO(this->get_logger(), "Baud rate: %d", baud_rate_);
   }
 
 private:
@@ -164,7 +162,6 @@ private:
   }
 
   std::string serial_port_;
-  int baud_rate_;
   
   std::map<int, rclcpp::Publisher<ddsm115_ros2_driver::msg::Ddsm115Status>::SharedPtr> status_pub_vec_;
   std::map<int, rclcpp::Subscription<ddsm115_ros2_driver::msg::Ddsm115Command>::SharedPtr> command_sub_vec_;


### PR DESCRIPTION
Remove the baud rate parameter from the `init_port` method and use a constant value instead, simplifying the initialization process. Update related code to reflect this change.